### PR TITLE
Threads in global plugin settings

### DIFF
--- a/modules/plugin/chowdsp_plugin_utils/Files/chowdsp_FileListener.cpp
+++ b/modules/plugin/chowdsp_plugin_utils/Files/chowdsp_FileListener.cpp
@@ -8,6 +8,11 @@ FileListener::FileListener (const juce::File& file, int timerSeconds) : fileToLi
     startTimer (timerSeconds * 1000);
 }
 
+FileListener::~FileListener()
+{
+    stopTimer();
+}
+
 void FileListener::timerCallback()
 {
     auto newModificationTime = fileToListenTo.getLastModificationTime().toMilliseconds();

--- a/modules/plugin/chowdsp_plugin_utils/Files/chowdsp_FileListener.h
+++ b/modules/plugin/chowdsp_plugin_utils/Files/chowdsp_FileListener.h
@@ -9,6 +9,8 @@ public:
     /** Initialize this FileListener for a given file and update time. */
     FileListener (const juce::File& file, int timerSeconds);
 
+    ~FileListener() override;
+
     /** Override this class to do something when the file has changed. */
     virtual void listenerFileChanged() = 0;
 

--- a/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.cpp
+++ b/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.cpp
@@ -20,7 +20,7 @@ void GlobalPluginSettings::SettingsFileListener::listenerFileChanged()
 void GlobalPluginSettings::initialise (const juce::String& settingsFile, int timerSeconds)
 {
     if (fileListener != nullptr)
-       return; // already initialised!
+        return; // already initialised!
 
     const juce::ScopedLock sl (lock);
     auto settingsDir = juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory);
@@ -178,7 +178,7 @@ void GlobalPluginSettings::writeSettingsToFile()
     if (fileListener == nullptr)
         return;
 
-    const juce::ScopedLock sl (lock);   
+    const juce::ScopedLock sl (lock);
     auto& settingsFile = fileListener->getListenerFile();
 
     json settingsJson;

--- a/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.cpp
+++ b/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.cpp
@@ -13,7 +13,7 @@ GlobalPluginSettings::SettingsFileListener::SettingsFileListener (const juce::Fi
 
 void GlobalPluginSettings::SettingsFileListener::listenerFileChanged()
 {
-    const juce::ScopedLock sl (globalSettings.getLock());
+    const juce::ScopedLock sl (globalSettings.lock);
     globalSettings.loadSettingsFromFile();
 }
 

--- a/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.cpp
+++ b/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.cpp
@@ -13,7 +13,6 @@ GlobalPluginSettings::SettingsFileListener::SettingsFileListener (const juce::Fi
 
 void GlobalPluginSettings::SettingsFileListener::listenerFileChanged()
 {
-    const juce::ScopedLock sl (globalSettings.lock);
     globalSettings.loadSettingsFromFile();
 }
 

--- a/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.cpp
+++ b/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.cpp
@@ -13,14 +13,16 @@ GlobalPluginSettings::SettingsFileListener::SettingsFileListener (const juce::Fi
 
 void GlobalPluginSettings::SettingsFileListener::listenerFileChanged()
 {
+    const juce::ScopedLock sl (globalSettings.getLock());
     globalSettings.loadSettingsFromFile();
 }
 
 void GlobalPluginSettings::initialise (const juce::String& settingsFile, int timerSeconds)
 {
     if (fileListener != nullptr)
-        return; // already initialised!
+       return; // already initialised!
 
+    const juce::ScopedLock sl (lock);
     auto settingsDir = juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory);
     fileListener = std::make_unique<SettingsFileListener> (settingsDir.getChildFile (settingsFile), timerSeconds, *this);
     if (! loadSettingsFromFile())
@@ -30,6 +32,7 @@ void GlobalPluginSettings::initialise (const juce::String& settingsFile, int tim
 void GlobalPluginSettings::addProperties (std::initializer_list<SettingProperty> properties, Listener* listener)
 {
     jassert (fileListener != nullptr); // Trying to add properties before initalizing? Don't do that!
+    const juce::ScopedLock sl (lock);
 
     for (auto& [name, value] : properties)
     {
@@ -37,13 +40,13 @@ void GlobalPluginSettings::addProperties (std::initializer_list<SettingProperty>
             globalProperties[name.data()] = std::move (value);
         addPropertyListener (name, listener);
     }
-
     writeSettingsToFile();
 }
 
 template <typename T>
 T GlobalPluginSettings::getProperty (SettingID name)
 {
+    const juce::ScopedLock sl (lock);
     try
     {
         return globalProperties[name.data()].get<T>();
@@ -60,6 +63,7 @@ T GlobalPluginSettings::getProperty (SettingID name)
 template <typename T>
 void GlobalPluginSettings::setProperty (SettingID name, T property)
 {
+    const juce::ScopedLock sl (lock);
     if (! globalProperties.contains (name))
     {
         // property must be added before it can be set!
@@ -109,6 +113,7 @@ void GlobalPluginSettings::removePropertyListener (Listener* listener)
 
 juce::File GlobalPluginSettings::getSettingsFile() const noexcept
 {
+    const juce::ScopedLock sl (lock);
     if (fileListener == nullptr)
         return {};
 
@@ -120,6 +125,7 @@ bool GlobalPluginSettings::loadSettingsFromFile()
     // this method should not be used before initialise()
     jassert (fileListener != nullptr);
 
+    const juce::ScopedLock sl (lock);
     auto& settingsFile = fileListener->getListenerFile();
     if (! settingsFile.existsAsFile())
         return false;
@@ -152,6 +158,7 @@ bool GlobalPluginSettings::loadSettingsFromFile()
         if (! JSONUtils::isSameType (value, newProperty))
         {
             // new property does not have the same type as the original!
+            // also hit when listenerFileChanged callback is hit and our properties are different then the settings file
             jassertfalse;
 
             newProperty = value;
@@ -163,7 +170,6 @@ bool GlobalPluginSettings::loadSettingsFromFile()
                 l->globalSettingChanged (name);
         }
     }
-
     return true;
 }
 
@@ -172,6 +178,7 @@ void GlobalPluginSettings::writeSettingsToFile()
     if (fileListener == nullptr)
         return;
 
+    const juce::ScopedLock sl (lock);   
     auto& settingsFile = fileListener->getListenerFile();
 
     json settingsJson;

--- a/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.h
+++ b/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.h
@@ -60,7 +60,6 @@ public:
     /** Returns the file be used to store the global settings */
     [[nodiscard]] juce::File getSettingsFile() const noexcept;
 
-
 private:
     bool loadSettingsFromFile();
     void writeSettingsToFile();

--- a/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.h
+++ b/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.h
@@ -60,7 +60,6 @@ public:
     /** Returns the file be used to store the global settings */
     [[nodiscard]] juce::File getSettingsFile() const noexcept;
 
-    const juce::CriticalSection& getLock() const noexcept { return lock; }
 
 private:
     bool loadSettingsFromFile();

--- a/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.h
+++ b/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.h
@@ -60,7 +60,7 @@ public:
     /** Returns the file be used to store the global settings */
     [[nodiscard]] juce::File getSettingsFile() const noexcept;
 
-    const juce::CriticalSection& getLock() const noexcept   { return lock; }
+    const juce::CriticalSection& getLock() const noexcept { return lock; }
 
 private:
     bool loadSettingsFromFile();
@@ -82,7 +82,7 @@ private:
     static constexpr SettingID settingsTag = "plugin_settings";
 
     inline static juce::CriticalSection lock;
-    
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GlobalPluginSettings)
 };
 

--- a/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.h
+++ b/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.h
@@ -60,6 +60,8 @@ public:
     /** Returns the file be used to store the global settings */
     [[nodiscard]] juce::File getSettingsFile() const noexcept;
 
+    const juce::CriticalSection& getLock() const noexcept   { return lock; }
+
 private:
     bool loadSettingsFromFile();
     void writeSettingsToFile();
@@ -79,6 +81,8 @@ private:
 
     static constexpr SettingID settingsTag = "plugin_settings";
 
+    inline static juce::CriticalSection lock;
+    
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GlobalPluginSettings)
 };
 

--- a/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.h
+++ b/modules/plugin/chowdsp_plugin_utils/SharedUtils/chowdsp_GlobalPluginSettings.h
@@ -79,7 +79,7 @@ private:
 
     static constexpr SettingID settingsTag = "plugin_settings";
 
-    inline static juce::CriticalSection lock;
+    juce::CriticalSection lock;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (GlobalPluginSettings)
 };

--- a/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
+++ b/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
@@ -252,7 +252,7 @@ public:
             [&] {
                 chowdsp::GlobalPluginSettings settings;
                 settings.initialise (settingsFile, 1);
-                for (int i = 10; i < 30; ++i)
+                for (int i = 20; i < 40; ++i)
                 {
                     chowdsp::GlobalPluginSettings::SettingProperty prop { std::to_string (i), i };
                     settings.addProperties ({ prop });
@@ -305,9 +305,10 @@ public:
 
         beginTest ("Wreck Settings File Test");
         wreckSettingsFile();
-
+        
         beginTest ("Two Instances Accessing Same File Test");
         twoInstancesAccessingSameFileTest();
+        
     }
 };
 

--- a/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
+++ b/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
@@ -225,7 +225,6 @@ public:
         }
     }
 
-
     /**
      * Kick off thread 1, read and write settings to one instance of GlobalPluginSettings
      * Kick off thread 2 read and write settings to another instance of GlobalPluginSettings
@@ -238,12 +237,12 @@ public:
             [&] {
                 chowdsp::GlobalPluginSettings settings;
                 settings.initialise (settingsFile, 1);
-                for(int i = 0; i < 20; ++i)
+                for (int i = 0; i < 20; ++i)
                 {
-                    chowdsp::GlobalPluginSettings::SettingProperty prop {std::to_string(i), i};
+                    chowdsp::GlobalPluginSettings::SettingProperty prop { std::to_string (i), i };
                     settings.addProperties ({ prop });
                     expectEquals (settings.getProperty<int> (prop.first), prop.second.get<int>(), "Property is incorrect within thread 1");
-                    juce::Thread::sleep (50); 
+                    juce::Thread::sleep (50);
                 }
                 thread1Finished = true;
             });
@@ -253,9 +252,9 @@ public:
             [&] {
                 chowdsp::GlobalPluginSettings settings;
                 settings.initialise (settingsFile, 1);
-                for(int i = 10; i < 30; ++i)
+                for (int i = 10; i < 30; ++i)
                 {
-                    chowdsp::GlobalPluginSettings::SettingProperty prop {std::to_string(i), i};
+                    chowdsp::GlobalPluginSettings::SettingProperty prop { std::to_string (i), i };
                     settings.addProperties ({ prop });
                     expectEquals (settings.getProperty<int> (prop.first), prop.second.get<int>(), "Property is incorrect within thread 2");
                     juce::Thread::sleep (50);
@@ -265,7 +264,7 @@ public:
 
         while (! (thread1Finished && thread2Finished))
             juce::MessageManager::getInstance()->runDispatchLoopUntil (100);
-        
+
         chowdsp::GlobalPluginSettings settings;
         settings.initialise (settingsFile, 1);
         settings.getSettingsFile().deleteFile();
@@ -306,10 +305,9 @@ public:
 
         beginTest ("Wreck Settings File Test");
         wreckSettingsFile();
-        
-        beginTest("Two Instances Accessing Same File Test");
+
+        beginTest ("Two Instances Accessing Same File Test");
         twoInstancesAccessingSameFileTest();
-        
     }
 };
 

--- a/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
+++ b/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
@@ -307,7 +307,7 @@ public:
 
         beginTest ("Wreck Settings File Test");
         wreckSettingsFile();
-        
+
         beginTest ("Two Instances Accessing Same File Test");
         twoInstancesAccessingSameFileTest();
     }

--- a/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
+++ b/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
@@ -305,10 +305,9 @@ public:
 
         beginTest ("Wreck Settings File Test");
         wreckSettingsFile();
-        
+
         beginTest ("Two Instances Accessing Same File Test");
         twoInstancesAccessingSameFileTest();
-        
     }
 };
 

--- a/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
+++ b/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
@@ -239,7 +239,7 @@ public:
                 settings.initialise (settingsFile, 1);
                 for (int i = 0; i < 20; ++i)
                 {
-                    auto propId = "thread1_" + std::to_string(i);
+                    auto propId = "thread1_" + std::to_string (i);
                     chowdsp::GlobalPluginSettings::SettingProperty prop { propId, i };
                     settings.addProperties ({ prop });
                     expectEquals (settings.getProperty<int> (prop.first), prop.second.get<int>(), "Property is incorrect within thread 1");
@@ -255,7 +255,7 @@ public:
                 settings.initialise (settingsFile, 1);
                 for (int i = 20; i < 40; ++i)
                 {
-                    auto propId = "thread2_" + std::to_string(i);
+                    auto propId = "thread2_" + std::to_string (i);
                     chowdsp::GlobalPluginSettings::SettingProperty prop { propId, i };
                     settings.addProperties ({ prop });
                     expectEquals (settings.getProperty<int> (prop.first), prop.second.get<int>(), "Property is incorrect within thread 2");

--- a/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
+++ b/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
@@ -239,7 +239,8 @@ public:
                 settings.initialise (settingsFile, 1);
                 for (int i = 0; i < 20; ++i)
                 {
-                    chowdsp::GlobalPluginSettings::SettingProperty prop { std::to_string (i), i };
+                    auto propId = "thread1_" + std::to_string(i);
+                    chowdsp::GlobalPluginSettings::SettingProperty prop { propId, i };
                     settings.addProperties ({ prop });
                     expectEquals (settings.getProperty<int> (prop.first), prop.second.get<int>(), "Property is incorrect within thread 1");
                     juce::Thread::sleep (50);
@@ -254,7 +255,8 @@ public:
                 settings.initialise (settingsFile, 1);
                 for (int i = 20; i < 40; ++i)
                 {
-                    chowdsp::GlobalPluginSettings::SettingProperty prop { std::to_string (i), i };
+                    auto propId = "thread2_" + std::to_string(i);
+                    chowdsp::GlobalPluginSettings::SettingProperty prop { propId, i };
                     settings.addProperties ({ prop });
                     expectEquals (settings.getProperty<int> (prop.first), prop.second.get<int>(), "Property is incorrect within thread 2");
                     juce::Thread::sleep (50);
@@ -305,7 +307,7 @@ public:
 
         beginTest ("Wreck Settings File Test");
         wreckSettingsFile();
-
+        
         beginTest ("Two Instances Accessing Same File Test");
         twoInstancesAccessingSameFileTest();
     }

--- a/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
+++ b/tests/plugin_tests/chowdsp_plugin_utils_test/GlobalSettingsTest.cpp
@@ -226,24 +226,26 @@ public:
     }
 
     /**
-     * Kick off thread 1, read and write settings to one instance of GlobalPluginSettings
-     * Kick off thread 2 read and write settings to another instance of GlobalPluginSettings
-     * sleep between read/writes to allow for listenerFileChanged callback to be hit, forcing both GlobalPluginSettings instances to read new information from file
+     * Primarily tests that the ScopedLock's within GlobalPluginSettings are working as they should
+     * Without the ScopedLock's in GlobalPluginSettings this test should have some random failing tests or cause a segmentation fault
      */
     void twoInstancesAccessingSameFileTest()
     {
+        chowdsp::SharedPluginSettings pluginSettings;
+        pluginSettings->initialise (settingsFile, 1);
+
         std::atomic<bool> thread1Finished { false };
         juce::Thread::launch (
             [&] {
-                chowdsp::GlobalPluginSettings settings;
-                settings.initialise (settingsFile, 1);
-                for (int i = 0; i < 20; ++i)
+                chowdsp::SharedPluginSettings thread1Settings;
+                thread1Settings->initialise (settingsFile, 1);
+                for (int i = 0; i < 400; ++i)
                 {
                     auto propId = "thread1_" + std::to_string (i);
                     chowdsp::GlobalPluginSettings::SettingProperty prop { propId, i };
-                    settings.addProperties ({ prop });
-                    expectEquals (settings.getProperty<int> (prop.first), prop.second.get<int>(), "Property is incorrect within thread 1");
-                    juce::Thread::sleep (50);
+                    thread1Settings->addProperties ({ prop });
+                    expectEquals (thread1Settings->getProperty<int> (prop.first), prop.second.get<int>(), "Property is incorrect within thread 1");
+                    juce::Thread::sleep (2); // allow thread 2 to get caught up so both threads are writing/reading at the same time
                 }
                 thread1Finished = true;
             });
@@ -251,15 +253,15 @@ public:
         std::atomic<bool> thread2Finished { false };
         juce::Thread::launch (
             [&] {
-                chowdsp::GlobalPluginSettings settings;
-                settings.initialise (settingsFile, 1);
-                for (int i = 20; i < 40; ++i)
+                chowdsp::SharedPluginSettings thread2Settings;
+                thread2Settings->initialise (settingsFile, 1);
+                for (int i = 0; i < 400; ++i)
                 {
                     auto propId = "thread2_" + std::to_string (i);
                     chowdsp::GlobalPluginSettings::SettingProperty prop { propId, i };
-                    settings.addProperties ({ prop });
-                    expectEquals (settings.getProperty<int> (prop.first), prop.second.get<int>(), "Property is incorrect within thread 2");
-                    juce::Thread::sleep (50);
+                    thread2Settings->addProperties ({ prop });
+                    expectEquals (thread2Settings->getProperty<int> (prop.first), prop.second.get<int>(), "Property is incorrect within thread 2");
+                    juce::Thread::sleep (1);
                 }
                 thread2Finished = true;
             });
@@ -267,9 +269,19 @@ public:
         while (! (thread1Finished && thread2Finished))
             juce::MessageManager::getInstance()->runDispatchLoopUntil (100);
 
-        chowdsp::GlobalPluginSettings settings;
-        settings.initialise (settingsFile, 1);
-        settings.getSettingsFile().deleteFile();
+        // Check settings were properly written to file
+        for(int i = 0; i < 400; ++i)
+        {
+            auto thread1PropId = "thread1_" + std::to_string (i);
+            chowdsp::GlobalPluginSettings::SettingProperty thread1Prop { thread1PropId, i };
+            expectEquals (pluginSettings->getProperty<int> (thread1Prop.first), thread1Prop.second.get<int>(), "Property is incorrect within final check");
+
+            auto thread2PropId = "thread2_" + std::to_string (i);
+            chowdsp::GlobalPluginSettings::SettingProperty thread2Prop { thread2PropId, i };
+            expectEquals (pluginSettings->getProperty<int> (thread2Prop.first), thread2Prop.second.get<int>(), "Property is incorrect within final check");
+        }
+
+        pluginSettings->getSettingsFile().deleteFile();
     }
 
     void runTestTimed() override


### PR DESCRIPTION
This ended up being trickier then I thought, I'm confident that this test properly tests multiple threads or processes accessing the GlobalPluginSettings, but it's possible I missed something.

Thanks!