### PR TITLE
Some small fixes

### DIFF
--- a/modules/dsp/chowdsp_eq/EQ/chowdsp_EQBand.cpp
+++ b/modules/dsp/chowdsp_eq/EQ/chowdsp_EQBand.cpp
@@ -284,7 +284,7 @@ void EQBand<FloatType, FilterChoices...>::processBlock (const chowdsp::BufferVie
 
     const auto needsFade = filterType != prevFilterType;
     if (needsFade)
-        BufferMath::copyBufferData (buffer, fadeBuffer, 0, numSamples, 0, numChannels);
+        BufferMath::copyBufferData (buffer, fadeBuffer, 0, numSamples, 0, 0, numChannels);
 
     TupleHelpers::forEachInTuple (
         [this, &buffer] (auto& filter, size_t filterIndex) {

--- a/modules/dsp/chowdsp_eq/EQ/chowdsp_EQBand.cpp
+++ b/modules/dsp/chowdsp_eq/EQ/chowdsp_EQBand.cpp
@@ -284,7 +284,7 @@ void EQBand<FloatType, FilterChoices...>::processBlock (const chowdsp::BufferVie
 
     const auto needsFade = filterType != prevFilterType;
     if (needsFade)
-        BufferMath::copyBufferData (buffer, fadeBuffer, 0, numSamples, 0, 0, numChannels);
+        BufferMath::copyBufferData (buffer, fadeBuffer, 0, 0, numSamples, 0, numChannels);
 
     TupleHelpers::forEachInTuple (
         [this, &buffer] (auto& filter, size_t filterIndex) {

--- a/modules/dsp/chowdsp_eq/EQ/chowdsp_EQProcessor.h
+++ b/modules/dsp/chowdsp_eq/EQ/chowdsp_EQProcessor.h
@@ -60,7 +60,7 @@ public:
 private:
     std::array<EQBandType, numBands> bands;
     std::array<BypassProcessor<FloatType>, numBands> bypasses;
-    std::array<bool, numBands> onOffs;
+    std::array<bool, numBands> onOffs = {false};
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (EQProcessor)
 };

--- a/modules/dsp/chowdsp_math/Math/chowdsp_BufferMath.cpp
+++ b/modules/dsp/chowdsp_math/Math/chowdsp_BufferMath.cpp
@@ -93,11 +93,10 @@ static void copyBufferData (const BufferType1& bufferSrc, BufferType2& bufferDes
         const auto* srcData = bufferSrc.getReadPointer (ch);
         auto* destData = bufferDest.getWritePointer (ch);
 
+        // If you're here, check that you're calling this function correctly,
+        // the channel is probably out of bounds. 
         jassert(destData != nullptr);
         jassert(srcData != nullptr);
-        if (!destData || !srcData) {
-            continue;
-        }
 
         if constexpr (std::is_floating_point_v<SampleType>)
         {

--- a/modules/dsp/chowdsp_math/Math/chowdsp_BufferMath.cpp
+++ b/modules/dsp/chowdsp_math/Math/chowdsp_BufferMath.cpp
@@ -93,6 +93,12 @@ static void copyBufferData (const BufferType1& bufferSrc, BufferType2& bufferDes
         const auto* srcData = bufferSrc.getReadPointer (ch);
         auto* destData = bufferDest.getWritePointer (ch);
 
+        jassert(destData != nullptr);
+        jassert(srcData != nullptr);
+        if (!destData || !srcData) {
+            continue;
+        }
+
         if constexpr (std::is_floating_point_v<SampleType>)
         {
             juce::FloatVectorOperations::copy (destData + destStartSample, srcData + srcStartSample, numSamples);


### PR DESCRIPTION
Just some small tidy-ups which could help resolve some issues we're seeing :-) 

It looks to me in chowdsp_EQBand.cpp:287, there is a slight mismatch of arguments:
```cpp

static void copyBufferData (       [287, BEFORE] BufferMath::copyBufferData (   [287, AFTER] BufferMath::copyBufferData (
  const BufferType1& bufferSrc,                 buffer                                        buffer,
  BufferType2& bufferDest,                      fadeBuffer                                    fadeBuffer,
  int srcStartSample,                           0,                                            0,
  int destStartSample,                          numSamples,                                   0,
  int numSamples,                               0,                                            numSamples,
  int startChannel,                             numChannels)                                  0,
  int numChannels) noexcept                                                                   numChannels)
```

And also sometimes the undefined sanitizer would raise an issue with the `onOffs` array being uninitialized, so I thought why not make that explicityly initialized :)