### PR TITLE
buffer iterators extended with samples iter and samples iter test

### DIFF
--- a/modules/dsp/chowdsp_dsp_data_structures/Buffers/chowdsp_BufferIterators.h
+++ b/modules/dsp/chowdsp_dsp_data_structures/Buffers/chowdsp_BufferIterators.h
@@ -218,7 +218,6 @@ namespace buffer_iters
         using BufferSampleType = typename BufferSampleTypeHelper<BufferType>::Type;
     } // namespace sample_type
 
-
     /** Iterates over a buffer's samples*/
     template <typename BufferType>
     constexpr auto samples (BufferType& buffer)
@@ -254,8 +253,9 @@ namespace buffer_iters
 
                     auto channelSpan = nonstd::span { std::as_const (channelData), (size_t) buffer.getNumChannels() };
 
-                    return std::make_tuple (sampleIndex, channelSpan); 
-                } else 
+                    return std::make_tuple (sampleIndex, channelSpan);
+                }
+                else
                 {
                     for (int channel { 0 }; channel < buffer.getNumChannels(); channel++)
                     {
@@ -278,7 +278,6 @@ namespace buffer_iters
         };
         return iterable_wrapper { buffer };
     }
-
 
 } // namespace buffer_iters
 

--- a/modules/plugin/chowdsp_plugin_state/Backend/chowdsp_PluginState.h
+++ b/modules/plugin/chowdsp_plugin_state/Backend/chowdsp_PluginState.h
@@ -67,6 +67,12 @@ public:
     /** Returns the plugin state's parameters */
     [[nodiscard]] const ParamHolder& getParameters() const { return *params; }
 
+    /** Returns the plugin non-parameter state */
+    [[nodiscard]] virtual NonParamState& getNonParameters() = 0;
+
+    /** Returns the plugin non-parameter state */
+    [[nodiscard]] virtual const NonParamState& getNonParameters() const = 0;
+
     /** Calls an action on the main thread via chowdsp::DeferredAction */
     template <typename Callable>
     void callOnMainThread (Callable&& func, bool couldBeAudioThread = false)

--- a/modules/plugin/chowdsp_plugin_state/Backend/chowdsp_PluginStateImpl.cpp
+++ b/modules/plugin/chowdsp_plugin_state/Backend/chowdsp_PluginStateImpl.cpp
@@ -84,4 +84,16 @@ void PluginStateImpl<ParameterState, NonParameterState, Serializer>::deserialize
     Serializer::template deserialize<Serializer, NonParamState> (Serializer::getChildElement (serial, nonParamStateChildIndex), object.nonParams);
     Serializer::template deserialize<Serializer, ParamHolder> (Serializer::getChildElement (serial, paramStateChildIndex), object.params);
 }
+
+template <typename ParameterState, typename NonParameterState, typename Serializer>
+NonParamState& PluginStateImpl<ParameterState, NonParameterState, Serializer>::getNonParameters()
+{
+    return nonParams;
+}
+
+template <typename ParameterState, typename NonParameterState, typename Serializer>
+const NonParamState& PluginStateImpl<ParameterState, NonParameterState, Serializer>::getNonParameters() const
+{
+    return nonParams;
+}
 } // namespace chowdsp

--- a/modules/plugin/chowdsp_plugin_state/Backend/chowdsp_PluginStateImpl.h
+++ b/modules/plugin/chowdsp_plugin_state/Backend/chowdsp_PluginStateImpl.h
@@ -36,6 +36,12 @@ public:
     template <typename>
     static void deserialize (typename Serializer::DeserializedType serial, PluginStateImpl& object);
 
+    /** Returns the plugin non-parameter state */
+    [[nodiscard]] NonParamState& getNonParameters() override;
+
+    /** Returns the plugin non-parameter state */
+    [[nodiscard]] const NonParamState& getNonParameters() const override;
+
     ParameterState params;
     NonParameterState nonParams;
 

--- a/modules/plugin/chowdsp_presets_v2/Backend/chowdsp_PresetManager.cpp
+++ b/modules/plugin/chowdsp_presets_v2/Backend/chowdsp_PresetManager.cpp
@@ -2,162 +2,16 @@
 
 namespace chowdsp::presets
 {
-void PresetManager::initializeListeners (ParamHolder& params, ParameterListeners& paramListeners)
+PresetManager::PresetManager (PluginState& state,
+                              juce::AudioProcessor* plugin,
+                              const juce::String& presetFileExtension,
+                              std::vector<juce::RangedAudioParameter*>&& presetAgnosticParams,
+                              PresetTree::InsertionHelper&& insertionHelper)
+    : saverLoader (state, plugin, std::move (presetAgnosticParams)),
+      presetTree (&saverLoader.getPresetState(), std::move (insertionHelper)),
+      presetFileExt (presetFileExtension)
 {
-    params.doForAllParameters (
-        [this, &paramListeners] (auto& param, size_t)
-        {
-            if (isPresetAgnosticParameter (param))
-                return;
-
-            listeners += {
-                paramListeners.addParameterListener (
-                    param,
-                    ParameterListenerThread::MessageThread,
-                    [this]
-                    {
-                        if (! areWeInTheMidstOfAPresetChange)
-                            isPresetDirty.set (true);
-                    })
-            };
-        });
-
-    listeners +=
-        {
-            isPresetDirty.changeBroadcaster.connect (
-                [this]
-                {
-                    if (! areWeInTheMidstOfAPresetChange)
-                        presetDirtyStatusBroadcaster();
-                }),
-            currentPreset.changeBroadcaster.connect (
-                [this]
-                {
-                    if (currentPreset == nullptr)
-                        return;
-
-                    juce::ScopedValueSetter svs { areWeInTheMidstOfAPresetChange, true };
-
-                    loadPresetState (currentPreset->getState()); // @TODO: could this throw?
-                    pluginState.getParameterListeners().updateBroadcastersFromMessageThread();
-                    isPresetDirty.set (false);
-                    presetChangedBroadcaster();
-
-                    if (processor != nullptr)
-                    {
-#if JUCE_VERSION > 0x60007
-                        processor->updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withProgramChanged (true));
-#else
-                        processor->updateHostDisplay();
-#endif
-                    }
-                })
-        };
-}
-
-void PresetManager::loadPreset (const Preset& preset)
-{
-    struct ChangePresetAction : juce::UndoableAction
-    {
-        explicit ChangePresetAction (PresetManager& mgr, const Preset& preset)
-            : manager (mgr),
-              performPreset (preset),
-              undoPreset (manager.currentPreset->getName(),
-                          manager.currentPreset->getVendor(),
-                          manager.savePresetState(),
-                          manager.currentPreset->getCategory(),
-                          manager.currentPreset->getPresetFile()),
-              previousStateWasDirty (manager.isPresetDirty)
-        {
-        }
-
-        bool perform() override
-        {
-            manager.currentPreset = performPreset;
-            return true;
-        }
-
-        bool undo() override
-        {
-            manager.currentPreset = undoPreset;
-            manager.isPresetDirty.set (previousStateWasDirty);
-            return true;
-        }
-
-        int getSizeInUnits() override { return (int) sizeof (*this); }
-
-        PresetManager& manager;
-        const Preset& performPreset;
-        const Preset undoPreset;
-        const bool previousStateWasDirty = false;
-    };
-
-    pluginState.callOnMainThread (
-        [this, &preset]
-        {
-            if (currentPreset == nullptr || pluginState.undoManager == nullptr)
-            {
-                currentPreset = preset;
-                return;
-            }
-
-            pluginState.undoManager->beginNewTransaction ("Loading preset: " + preset.getName());
-            pluginState.undoManager->perform (std::make_unique<ChangePresetAction> (*this, preset).release());
-        });
-}
-
-bool PresetManager::isPresetAgnosticParameter (const juce::RangedAudioParameter& param) const
-{
-    return std::find_if (
-               presetAgnosticParameters.begin(),
-               presetAgnosticParameters.end(),
-               [&param] (const juce::RangedAudioParameter* presetAgnosticParam)
-               {
-                   return param.paramID == presetAgnosticParam->paramID;
-               })
-           != presetAgnosticParameters.end();
-}
-
-nlohmann::json PresetManager::savePresetState()
-{
-    nlohmann::json state;
-    std::as_const (pluginState)
-        .getParameters()
-        .doForAllParameters (
-            [this, &state] (auto& param, size_t)
-            {
-                if (isPresetAgnosticParameter (param))
-                    return;
-
-                state[param.paramID.toStdString()] = ParameterTypeHelpers::getValue (param);
-            });
-    return state;
-}
-
-void PresetManager::loadPresetState (const nlohmann::json& state)
-{
-    if (currentPreset != nullptr)
-    {
-        const auto newPresetName = currentPreset->getName();
-        juce::Logger::writeToLog ("Loading preset: " + newPresetName);
-    }
-
-    pluginState
-        .getParameters()
-        .doForAllParameters (
-            [this, &state] (auto& param, size_t)
-            {
-                if (isPresetAgnosticParameter (param))
-                    return;
-
-                if (state.contains (param.paramID.toStdString()))
-                {
-                    ParameterTypeHelpers::setValue (state[param.paramID.toStdString()], param);
-                    return;
-                }
-
-                ParameterTypeHelpers::resetParameter (param);
-            });
+    jassert (presetFileExt[0] == '.'); // invalid file extension!
 }
 
 void PresetManager::addPresets (std::vector<Preset>&& presets, bool areFactoryPresets)
@@ -182,7 +36,7 @@ Preset PresetManager::getUserPresetForState (const juce::String& presetName, nlo
 void PresetManager::saveUserPreset (const juce::File& file)
 {
     const auto name = file.getFileNameWithoutExtension();
-    saveUserPreset (file, Preset { name, userPresetsVendor, savePresetState() });
+    saveUserPreset (file, Preset { name, userPresetsVendor, saverLoader.savePresetState() });
 }
 
 void PresetManager::saveUserPreset (const juce::File& file, Preset&& preset) // NOSONAR

--- a/modules/plugin/chowdsp_presets_v2/Backend/chowdsp_PresetSaverLoader.cpp
+++ b/modules/plugin/chowdsp_presets_v2/Backend/chowdsp_PresetSaverLoader.cpp
@@ -1,0 +1,173 @@
+#include "chowdsp_PresetSaverLoader.h"
+
+namespace chowdsp::presets
+{
+PresetSaverLoader::PresetSaverLoader (PluginState& state,
+                                      juce::AudioProcessor* plugin,
+                                      std::vector<juce::RangedAudioParameter*>&& presetAgnosticParams)
+    : processor (plugin),
+      pluginState (state),
+      presetAgnosticParameters (std::move (presetAgnosticParams))
+{
+    state.getNonParameters().addStateValues ({ &currentPreset, &isPresetDirty });
+    initializeListeners (state.getParameters(), state.getParameterListeners());
+}
+
+void PresetSaverLoader::initializeListeners (ParamHolder& params, ParameterListeners& paramListeners)
+{
+    params.doForAllParameters (
+        [this, &paramListeners] (auto& param, size_t)
+        {
+            if (isPresetAgnosticParameter (param))
+                return;
+
+            listeners += {
+                paramListeners.addParameterListener (
+                    param,
+                    ParameterListenerThread::MessageThread,
+                    [this]
+                    {
+                        if (! areWeInTheMidstOfAPresetChange)
+                            isPresetDirty.set (true);
+                    })
+            };
+        });
+
+    listeners +=
+        {
+            isPresetDirty.changeBroadcaster.connect (
+                [this]
+                {
+                    if (! areWeInTheMidstOfAPresetChange)
+                        presetDirtyStatusBroadcaster();
+                }),
+            currentPreset.changeBroadcaster.connect (
+                [this]
+                {
+                    if (currentPreset == nullptr)
+                        return;
+
+                    juce::ScopedValueSetter svs { areWeInTheMidstOfAPresetChange, true };
+
+                    loadPresetState (currentPreset->getState()); // @TODO: could this throw?
+                    pluginState.getParameterListeners().updateBroadcastersFromMessageThread();
+                    isPresetDirty.set (false);
+                    presetChangedBroadcaster();
+
+                    if (processor != nullptr)
+                    {
+#if JUCE_VERSION > 0x60007
+                        processor->updateHostDisplay (juce::AudioProcessorListener::ChangeDetails().withProgramChanged (true));
+#else
+                        processor->updateHostDisplay();
+#endif
+                    }
+                })
+        };
+}
+
+void PresetSaverLoader::loadPreset (const Preset& preset)
+{
+    struct ChangePresetAction : juce::UndoableAction
+    {
+        explicit ChangePresetAction (PresetSaverLoader& sl, const Preset& preset)
+            : saverLoader (sl),
+              performPreset (preset),
+              undoPreset (saverLoader.currentPreset->getName(),
+                          saverLoader.currentPreset->getVendor(),
+                          saverLoader.savePresetState(),
+                          saverLoader.currentPreset->getCategory(),
+                          saverLoader.currentPreset->getPresetFile()),
+              previousStateWasDirty (saverLoader.isPresetDirty)
+        {
+        }
+
+        bool perform() override
+        {
+            saverLoader.currentPreset = performPreset;
+            return true;
+        }
+
+        bool undo() override
+        {
+            saverLoader.currentPreset = undoPreset;
+            saverLoader.isPresetDirty.set (previousStateWasDirty);
+            return true;
+        }
+
+        int getSizeInUnits() override { return (int) sizeof (*this); }
+
+        PresetSaverLoader& saverLoader;
+        const Preset& performPreset;
+        const Preset undoPreset;
+        const bool previousStateWasDirty = false;
+    };
+
+    pluginState.callOnMainThread (
+        [this, &preset]
+        {
+            if (currentPreset == nullptr || pluginState.undoManager == nullptr)
+            {
+                currentPreset = preset;
+                return;
+            }
+
+            pluginState.undoManager->beginNewTransaction ("Loading preset: " + preset.getName());
+            pluginState.undoManager->perform (std::make_unique<ChangePresetAction> (*this, preset).release());
+        });
+}
+
+bool PresetSaverLoader::isPresetAgnosticParameter (const juce::RangedAudioParameter& param) const
+{
+    return std::find_if (
+               presetAgnosticParameters.begin(),
+               presetAgnosticParameters.end(),
+               [&param] (const juce::RangedAudioParameter* presetAgnosticParam)
+               {
+                   return param.paramID == presetAgnosticParam->paramID;
+               })
+           != presetAgnosticParameters.end();
+}
+
+nlohmann::json PresetSaverLoader::savePresetParameters()
+{
+    nlohmann::json state;
+    std::as_const (pluginState)
+        .getParameters()
+        .doForAllParameters (
+            [this, &state] (auto& param, size_t)
+            {
+                if (isPresetAgnosticParameter (param))
+                    return;
+
+                state[param.paramID.toStdString()] = ParameterTypeHelpers::getValue (param);
+            });
+    return state;
+}
+
+void PresetSaverLoader::loadPresetParameters (const nlohmann::json& state)
+{
+    if (currentPreset != nullptr)
+    {
+        const auto newPresetName = currentPreset->getName();
+        juce::Logger::writeToLog ("Loading preset: " + newPresetName);
+    }
+
+    pluginState
+        .getParameters()
+        .doForAllParameters (
+            [this, &state] (auto& param, size_t)
+            {
+                if (isPresetAgnosticParameter (param))
+                    return;
+
+                if (state.contains (param.paramID.toStdString()))
+                {
+                    ParameterTypeHelpers::setValue (state[param.paramID.toStdString()], param);
+                    return;
+                }
+
+                ParameterTypeHelpers::resetParameter (param);
+            });
+}
+} // namespace chowdsp::presets

--- a/modules/plugin/chowdsp_presets_v2/Backend/chowdsp_PresetSaverLoader.h
+++ b/modules/plugin/chowdsp_presets_v2/Backend/chowdsp_PresetSaverLoader.h
@@ -1,0 +1,64 @@
+#pragma once
+
+namespace chowdsp::presets
+{
+/** Helper class for saving and loading plugin presets. */
+class PresetSaverLoader
+{
+public:
+    explicit PresetSaverLoader (PluginState& state,
+                                juce::AudioProcessor* plugin = nullptr,
+                                std::vector<juce::RangedAudioParameter*>&& presetAgnosticParams = {});
+
+    /** Returns the currently loaded preset, or nullptr if no preset is loaded. */
+    [[nodiscard]] const Preset* getCurrentPreset() const { return currentPreset.get(); }
+
+    /** Returns the preset state object used by this class. */
+    [[nodiscard]] PresetState& getPresetState() { return currentPreset; }
+
+    /** Returns true if the currently loaded preset is "dirty". */
+    [[nodiscard]] bool getIsPresetDirty() const noexcept { return isPresetDirty.get(); }
+
+    /** Loads a preset by reference. */
+    void loadPreset (const Preset& preset);
+
+    /** Returns true if the given parameter is preset-agnostic */
+    bool isPresetAgnosticParameter (const juce::RangedAudioParameter& param) const;
+
+    /** Returns a json object containing the plugin's preset state. */
+    std::function<nlohmann::json()> savePresetState = [this]
+    { return savePresetParameters(); };
+
+    /** Sets the plugin state from a given preset state. */
+    std::function<void (const nlohmann::json& state)> loadPresetState = [this] (const nlohmann::json& state)
+    { loadPresetParameters (state); };
+
+    /** Saves the parameters from a preset state. */
+    nlohmann::json savePresetParameters();
+
+    /** Loads the parameters from a preset state. */
+    void loadPresetParameters (const nlohmann::json& state);
+
+    /** Called when the current preset has changed. */
+    Broadcaster<void()> presetChangedBroadcaster {};
+
+    /** Called whenever the current preset's "dirty" status has changed. */
+    Broadcaster<void()> presetDirtyStatusBroadcaster {};
+
+private:
+    void initializeListeners (ParamHolder& params, ParameterListeners& listeners);
+
+    PresetState currentPreset;
+    StateValue<bool> isPresetDirty { "chowdsp_is_preset_dirty", false };
+
+    juce::AudioProcessor* processor = nullptr;
+    chowdsp::PluginState& pluginState;
+
+    const std::vector<juce::RangedAudioParameter*> presetAgnosticParameters {};
+    chowdsp::ScopedCallbackList listeners;
+
+    bool areWeInTheMidstOfAPresetChange = false;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PresetSaverLoader)
+};
+} // namespace chowdsp::presets

--- a/modules/plugin/chowdsp_presets_v2/Frontend/chowdsp_PresetsFileInterface.cpp
+++ b/modules/plugin/chowdsp_presets_v2/Frontend/chowdsp_PresetsFileInterface.cpp
@@ -15,7 +15,7 @@ FileInterface::FileInterface (PresetManager& manager,
 void FileInterface::savePreset()
 {
     jassert (savePresetCallback != nullptr);
-    savePresetCallback (presetManager.savePresetState());
+    savePresetCallback (presetManager.getSaveLoadHelper().savePresetState());
 }
 
 void FileInterface::resaveCurrentPreset()
@@ -28,7 +28,7 @@ void FileInterface::resaveCurrentPreset()
         Preset {
             currentPreset->getName(),
             currentPreset->getVendor(),
-            presetManager.savePresetState(),
+            presetManager.getSaveLoadHelper().savePresetState(),
             currentPreset->getCategory(),
             currentPreset->getPresetFile() });
 }

--- a/modules/plugin/chowdsp_presets_v2/Frontend/chowdsp_PresetsNextPreviousInterface.cpp
+++ b/modules/plugin/chowdsp_presets_v2/Frontend/chowdsp_PresetsNextPreviousInterface.cpp
@@ -4,9 +4,8 @@ namespace chowdsp::presets::frontend
 {
 NextPrevious::NextPrevious (PresetManager& manager) : presetManager (manager)
 {
-    presetChangedCallback = presetManager.presetChangedBroadcaster
-                                .connect ([this]
-                                          { updateCurrentPresetIndex(); });
+    presetChangedCallback = presetManager.getSaveLoadHelper().presetChangedBroadcaster.connect ([this]
+                                                                                                { updateCurrentPresetIndex(); });
     updateCurrentPresetIndex();
 }
 

--- a/modules/plugin/chowdsp_presets_v2/Frontend/chowdsp_PresetsTextInterface.cpp
+++ b/modules/plugin/chowdsp_presets_v2/Frontend/chowdsp_PresetsTextInterface.cpp
@@ -5,10 +5,10 @@ namespace chowdsp::presets::frontend
 TextInterface::TextInterface (PresetManager& manager) : presetManager (manager)
 {
     listeners += {
-        presetManager.presetChangedBroadcaster.connect ([this]
-                                                        { updateText(); }),
-        presetManager.presetDirtyStatusBroadcaster.connect ([this]
-                                                            { updateText(); }),
+        presetManager.getSaveLoadHelper().presetChangedBroadcaster.connect ([this]
+                                                                            { updateText(); }),
+        presetManager.getSaveLoadHelper().presetDirtyStatusBroadcaster.connect ([this]
+                                                                                { updateText(); }),
     };
 
     updateText();

--- a/modules/plugin/chowdsp_presets_v2/chowdsp_presets_v2.cpp
+++ b/modules/plugin/chowdsp_presets_v2/chowdsp_presets_v2.cpp
@@ -3,6 +3,7 @@
 #include "Backend/chowdsp_Preset.cpp"
 #include "Backend/chowdsp_PresetState.cpp"
 #include "Backend/chowdsp_PresetTree.cpp"
+#include "Backend/chowdsp_PresetSaverLoader.cpp"
 #include "Backend/chowdsp_PresetManager.cpp"
 
 #include "Frontend/chowdsp_PresetsProgramAdapter.cpp"

--- a/modules/plugin/chowdsp_presets_v2/chowdsp_presets_v2.h
+++ b/modules/plugin/chowdsp_presets_v2/chowdsp_presets_v2.h
@@ -29,6 +29,7 @@ BEGIN_JUCE_MODULE_DECLARATION
 #include "Backend/chowdsp_Preset.h"
 #include "Backend/chowdsp_PresetState.h"
 #include "Backend/chowdsp_PresetTree.h"
+#include "Backend/chowdsp_PresetSaverLoader.h"
 #include "Backend/chowdsp_PresetManager.h"
 
 namespace chowdsp

--- a/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
+++ b/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
@@ -64,7 +64,7 @@ TEMPLATE_TEST_CASE ("Buffer Iterators Test",
         }
 
         int count = 0;
-        for (auto [sample, data] : chowdsp::buffer_iters::samples (std::as_const(buffer)))
+        for (auto [sample, data] : chowdsp::buffer_iters::samples (std::as_const (buffer)))
         {
             for (auto& x_n : data)
                 REQUIRE (chowdsp::SIMDUtils::all ((SampleType) static_cast<float> (count++) == *x_n));


### PR DESCRIPTION
chowdsp::buffer_iters::samples() added to buffer iterators
chowdsp::buffer_iters::samples() test added to buffer iterator tests
currently should only work for `juce::AudioBuffer<float>` or `juce::AudioBuffer<double>` (const or non-const)