### PR TITLE
Extend Buffer Iterators With Sample First Iterator

### DIFF
--- a/modules/dsp/chowdsp_dsp_data_structures/Buffers/chowdsp_BufferIterators.h
+++ b/modules/dsp/chowdsp_dsp_data_structures/Buffers/chowdsp_BufferIterators.h
@@ -78,22 +78,22 @@ namespace buffer_iters
     template <typename BufferType>
     constexpr auto samples (BufferType& buffer)
     {
-        struct iterator 
+        struct iterator
         {
             BufferType& buffer;
             int sampleIndex;
             const float* channelData[CHOWDSP_BUFFER_MAX_NUM_CHANNELS];
-            
+
             bool operator!= (const iterator& other) const
             {
                 return &buffer != &other.buffer || sampleIndex != other.sampleIndex;
             }
-            
+
             void operator++()
             {
                 ++sampleIndex;
             }
-            
+
             auto operator*()
             {
                 if constexpr (IsConstBufferType<BufferType>)
@@ -101,39 +101,39 @@ namespace buffer_iters
 #if CHOWDSP_USING_JUCE
                     if constexpr (std::is_same_v<BufferType, const juce::AudioBuffer<float>> || std::is_same_v<BufferType, const juce::AudioBuffer<double>>)
                     {
-                        for (int channel{0}; channel < buffer.getNumChannels(); channel++)
+                        for (int channel { 0 }; channel < buffer.getNumChannels(); channel++)
                         {
-                            channelData[channel] = &buffer.getReadPointer(channel)[sampleIndex];
+                            channelData[channel] = &buffer.getReadPointer (channel)[sampleIndex];
                         }
-                        
-                        auto channelSpan = nonstd::span{std::as_const(channelData), (size_t)buffer.getNumChannels()};
-                        
-                        return std::make_tuple(sampleIndex, channelSpan);
-                    } else if (std::is_same_v<BufferType, juce::AudioBuffer<float>> || std::is_same_v<BufferType, juce::AudioBuffer<double>>)
+
+                        auto channelSpan = nonstd::span { std::as_const (channelData), (size_t) buffer.getNumChannels() };
+
+                        return std::make_tuple (sampleIndex, channelSpan);
+                    }
+                    else if (std::is_same_v<BufferType, juce::AudioBuffer<float>> || std::is_same_v<BufferType, juce::AudioBuffer<double>>)
                     {
-                        for (int channel{0}; channel < buffer.getNumChannels(); channel++)
+                        for (int channel { 0 }; channel < buffer.getNumChannels(); channel++)
                         {
-                            channelData[channel] = &buffer.getReadPointer(channel)[sampleIndex];
+                            channelData[channel] = &buffer.getReadPointer (channel)[sampleIndex];
                         }
-                        
-                        auto channelSpan = nonstd::span{std::as_const(channelData), (size_t)buffer.getNumChannels()};
-                        
+
+                        auto channelSpan = nonstd::span { std::as_const (channelData), (size_t) buffer.getNumChannels() };
+
                         //return
-                        return std::make_tuple(sampleIndex, channelSpan);
+                        return std::make_tuple (sampleIndex, channelSpan);
                     }
                 }
-      #endif
+#endif
             }
         };
-       struct iterable_wrapper
-       {
+        struct iterable_wrapper
+        {
             BufferType& buffer;
             auto begin() { return iterator { buffer, 0 }; }
             auto end() { return iterator { buffer, buffer.getNumSamples() }; }
         };
         return iterable_wrapper { buffer };
     }
-    
 
     /**
      * Iterates over a buffer in sub-blocks.

--- a/modules/dsp/chowdsp_dsp_data_structures/Buffers/chowdsp_BufferIterators.h
+++ b/modules/dsp/chowdsp_dsp_data_structures/Buffers/chowdsp_BufferIterators.h
@@ -218,7 +218,6 @@ namespace buffer_iters
         using BufferSampleType = typename BufferSampleTypeHelper<BufferType>::Type;
     } // namespace sample_type
 
-
     /** Iterates over a buffer's samples*/
     template <typename BufferType>
     constexpr auto samples (BufferType& buffer)
@@ -254,8 +253,9 @@ namespace buffer_iters
 
                     auto channelSpan = nonstd::span { std::as_const (channelData), (size_t) buffer.getNumChannels() };
 
-                    return std::make_tuple (sampleIndex, channelSpan); 
-                } else 
+                    return std::make_tuple (sampleIndex, channelSpan);
+                }
+                else
                 {
                     for (int channel { 0 }; channel < buffer.getNumChannels(); channel++)
                     {
@@ -278,7 +278,6 @@ namespace buffer_iters
         };
         return iterable_wrapper { buffer };
     }
-
 
 } // namespace buffer_iters
 

--- a/modules/dsp/chowdsp_dsp_data_structures/Buffers/chowdsp_BufferIterators.h
+++ b/modules/dsp/chowdsp_dsp_data_structures/Buffers/chowdsp_BufferIterators.h
@@ -74,67 +74,6 @@ namespace buffer_iters
         return channels<const BufferView<SampleType>> (buffer);
     }
 
-    /** Iterates over a buffer's samples*/
-    template <typename BufferType>
-    constexpr auto samples (BufferType& buffer)
-    {
-        struct iterator
-        {
-            BufferType& buffer;
-            int sampleIndex;
-            const float* channelData[CHOWDSP_BUFFER_MAX_NUM_CHANNELS];
-
-            bool operator!= (const iterator& other) const
-            {
-                return &buffer != &other.buffer || sampleIndex != other.sampleIndex;
-            }
-
-            void operator++()
-            {
-                ++sampleIndex;
-            }
-
-            auto operator*()
-            {
-                if constexpr (IsConstBufferType<BufferType>)
-                {
-#if CHOWDSP_USING_JUCE
-                    if constexpr (std::is_same_v<BufferType, const juce::AudioBuffer<float>> || std::is_same_v<BufferType, const juce::AudioBuffer<double>>)
-                    {
-                        for (int channel { 0 }; channel < buffer.getNumChannels(); channel++)
-                        {
-                            channelData[channel] = &buffer.getReadPointer (channel)[sampleIndex];
-                        }
-
-                        auto channelSpan = nonstd::span { std::as_const (channelData), (size_t) buffer.getNumChannels() };
-
-                        return std::make_tuple (sampleIndex, channelSpan);
-                    }
-                    else if (std::is_same_v<BufferType, juce::AudioBuffer<float>> || std::is_same_v<BufferType, juce::AudioBuffer<double>>)
-                    {
-                        for (int channel { 0 }; channel < buffer.getNumChannels(); channel++)
-                        {
-                            channelData[channel] = &buffer.getReadPointer (channel)[sampleIndex];
-                        }
-
-                        auto channelSpan = nonstd::span { std::as_const (channelData), (size_t) buffer.getNumChannels() };
-
-                        //return
-                        return std::make_tuple (sampleIndex, channelSpan);
-                    }
-                }
-#endif
-            }
-        };
-        struct iterable_wrapper
-        {
-            BufferType& buffer;
-            auto begin() { return iterator { buffer, 0 }; }
-            auto end() { return iterator { buffer, buffer.getNumSamples() }; }
-        };
-        return iterable_wrapper { buffer };
-    }
-
     /**
      * Iterates over a buffer in sub-blocks.
      *
@@ -250,6 +189,97 @@ namespace buffer_iters
     {
         return sub_blocks<subBlockSize, channelWise, const BufferView<SampleType>> (buffer);
     }
+
+    /** sample type helper*/
+    namespace sample_type
+    {
+        template <typename BufferType>
+        struct BufferSampleTypeHelper
+        {
+            using Type = std::remove_const_t<typename BufferType::Type>;
+        };
+
+#if CHOWDSP_USING_JUCE
+        template <>
+        struct BufferSampleTypeHelper<juce::AudioBuffer<float>>
+        {
+            using Type = float;
+        };
+
+        template <>
+        struct BufferSampleTypeHelper<juce::AudioBuffer<double>>
+        {
+            using Type = double;
+        };
+#endif
+
+        /** Template helper for getting the sample type from a buffer. */
+        template <typename BufferType>
+        using BufferSampleType = typename BufferSampleTypeHelper<BufferType>::Type;
+    } // namespace sample_type
+
+
+    /** Iterates over a buffer's samples*/
+    template <typename BufferType>
+    constexpr auto samples (BufferType& buffer)
+    {
+        struct iterator
+        {
+            using SampleType = sample_type::BufferSampleType<std::remove_const_t<BufferType>>;
+            using SamplePtrType = typename std::conditional_t<IsConstBufferType<BufferType>, const SampleType*, SampleType*>;
+
+            BufferType& buffer;
+            int sampleIndex;
+            SamplePtrType channelData[CHOWDSP_BUFFER_MAX_NUM_CHANNELS];
+
+            bool operator!= (const iterator& other) const
+            {
+                return &buffer != &other.buffer || sampleIndex != other.sampleIndex;
+            }
+
+            void operator++()
+            {
+                ++sampleIndex;
+            }
+
+            auto operator*()
+            {
+                if constexpr (IsConstBufferType<BufferType>)
+                {
+#if CHOWDSP_USING_JUCE
+                    for (int channel { 0 }; channel < buffer.getNumChannels(); channel++)
+                    {
+                        channelData[channel] = &buffer.getReadPointer (channel)[sampleIndex];
+                    }
+
+                    auto channelSpan = nonstd::span { std::as_const (channelData), (size_t) buffer.getNumChannels() };
+
+                    return std::make_tuple (sampleIndex, channelSpan); 
+                } else 
+                {
+                    for (int channel { 0 }; channel < buffer.getNumChannels(); channel++)
+                    {
+                        channelData[channel] = &buffer.getWritePointer (channel)[sampleIndex];
+                    }
+
+                    auto channelSpan = nonstd::span { std::as_const (channelData), (size_t) buffer.getNumChannels() };
+
+                    return std::make_tuple (sampleIndex, channelSpan);
+                }
+#endif
+            }
+        };
+
+        struct iterable_wrapper
+        {
+            BufferType& buffer;
+            auto begin() { return iterator { buffer, 0 }; }
+            auto end() { return iterator { buffer, buffer.getNumSamples() }; }
+        };
+        return iterable_wrapper { buffer };
+    }
+
+
 } // namespace buffer_iters
 
 } // namespace chowdsp

--- a/modules/dsp/chowdsp_dsp_data_structures/Buffers/chowdsp_BufferIterators.h
+++ b/modules/dsp/chowdsp_dsp_data_structures/Buffers/chowdsp_BufferIterators.h
@@ -190,7 +190,11 @@ namespace buffer_iters
         return sub_blocks<subBlockSize, channelWise, const BufferView<SampleType>> (buffer);
     }
 
-    /** sample type helper*/
+    /**
+     * sample type helper
+     *
+     * @TODO (Jatin): this is currently a duplicate of the same class in chowdsp::BufferMath::detail
+     */
     namespace sample_type
     {
         template <typename BufferType>
@@ -245,7 +249,6 @@ namespace buffer_iters
             {
                 if constexpr (IsConstBufferType<BufferType>)
                 {
-#if CHOWDSP_USING_JUCE
                     for (int channel { 0 }; channel < buffer.getNumChannels(); channel++)
                     {
                         channelData[channel] = &buffer.getReadPointer (channel)[sampleIndex];
@@ -266,7 +269,6 @@ namespace buffer_iters
 
                     return std::make_tuple (sampleIndex, channelSpan);
                 }
-#endif
             }
         };
 
@@ -280,5 +282,4 @@ namespace buffer_iters
     }
 
 } // namespace buffer_iters
-
 } // namespace chowdsp

--- a/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
+++ b/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
@@ -49,9 +49,9 @@ TEMPLATE_TEST_CASE ("Buffer Iterators Test",
                 REQUIRE (chowdsp::SIMDUtils::all ((SampleType) static_cast<float> (count++) == x_n));
         }
     }
-    
+
     SECTION ("Samples")
-    { 
+    {
         // juce::AudioBuffer<float> buffer(2, 4);
         BufferType buffer { 2, 4 };
 

--- a/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
+++ b/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
@@ -59,7 +59,7 @@ TEMPLATE_TEST_CASE ("Buffer Iterators Test",
             for (auto [sample, data] : chowdsp::buffer_iters::samples (buffer))
             {
                 for (auto& x_n : data)
-                    *x_n = static_cast<float> (count++);
+                    *x_n = (SampleType) static_cast<float> (count++);
             }
         }
 
@@ -91,8 +91,7 @@ TEMPLATE_TEST_CASE ("Buffer Iterators Test",
             int count = 0;
             for (const auto [channel, data] : chowdsp::buffer_iters::channels (constBufferView))
             {
-                const auto ddd = data;
-                REQUIRE (data.size() == bufferView.getNumSamples());
+                REQUIRE ((int) data.size() == bufferView.getNumSamples());
                 for (auto& x_n : data)
                 {
                     REQUIRE (chowdsp::SIMDUtils::all ((SampleType) static_cast<float> (count) == x_n));

--- a/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
+++ b/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
@@ -64,7 +64,7 @@ TEMPLATE_TEST_CASE ("Buffer Iterators Test",
         }
 
         int count = 0;
-        for (auto [sample, data] : chowdsp::buffer_iters::samples (std::as_const(buffer)))
+        for (auto [sample, data] : chowdsp::buffer_iters::samples (std::as_const (buffer)))
         {
             for (auto& x_n : data)
                 REQUIRE (chowdsp::SIMDUtils::all ((SampleType) static_cast<float> (count++) == *x_n));

--- a/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
+++ b/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
@@ -52,7 +52,6 @@ TEMPLATE_TEST_CASE ("Buffer Iterators Test",
 
     SECTION ("Samples")
     {
-        // juce::AudioBuffer<float> buffer(2, 4);
         BufferType buffer { 2, 4 };
 
         {
@@ -60,12 +59,12 @@ TEMPLATE_TEST_CASE ("Buffer Iterators Test",
             for (auto [sample, data] : chowdsp::buffer_iters::samples (buffer))
             {
                 for (auto& x_n : data)
-                    *x_n = (SampleType) static_cast<float> (count++);
+                    *x_n = static_cast<float> (count++);
             }
         }
 
         int count = 0;
-        for (auto [sample, data] : chowdsp::buffer_iters::samples (std::as_const (buffer)))
+        for (auto [sample, data] : chowdsp::buffer_iters::samples (std::as_const(buffer)))
         {
             for (auto& x_n : data)
                 REQUIRE (chowdsp::SIMDUtils::all ((SampleType) static_cast<float> (count++) == *x_n));

--- a/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
+++ b/tests/dsp_tests/chowdsp_dsp_juce_test/data_structures_tests/BufferIteratorsTest.cpp
@@ -49,6 +49,28 @@ TEMPLATE_TEST_CASE ("Buffer Iterators Test",
                 REQUIRE (chowdsp::SIMDUtils::all ((SampleType) static_cast<float> (count++) == x_n));
         }
     }
+    
+    SECTION ("Samples")
+    { 
+        // juce::AudioBuffer<float> buffer(2, 4);
+        BufferType buffer { 2, 4 };
+
+        {
+            int count = 0;
+            for (auto [sample, data] : chowdsp::buffer_iters::samples (buffer))
+            {
+                for (auto& x_n : data)
+                    *x_n = (SampleType) static_cast<float> (count++);
+            }
+        }
+
+        int count = 0;
+        for (auto [sample, data] : chowdsp::buffer_iters::samples (std::as_const (buffer)))
+        {
+            for (auto& x_n : data)
+                REQUIRE (chowdsp::SIMDUtils::all ((SampleType) static_cast<float> (count++) == *x_n));
+        }
+    }
 
     if constexpr (std::is_same_v<BufferType, chowdsp::Buffer<float>>)
     {


### PR DESCRIPTION
extended the buffer iterators with chowdsp::buffer_iters::samples() so that buffers can be iterated over sample first 