### PR TITLE
Fixed a compiler error by removing imported namespace

### DIFF
--- a/modules/dsp/chowdsp_simd/SIMD/chowdsp_SIMDComplexMathOps.h
+++ b/modules/dsp/chowdsp_simd/SIMD/chowdsp_SIMDComplexMathOps.h
@@ -4,8 +4,6 @@ namespace chowdsp::SIMDUtils
 {
 // @TODO: Remove all these ops once XSIMD has subsumed them (hopefully)
 
-using namespace SampleTypeHelpers;
-
 template <typename Type>
 inline xsimd::batch<Type> SIMDComplexMulReal (const xsimd::batch<std::complex<Type>>& a, const xsimd::batch<std::complex<Type>>& b)
 {
@@ -20,7 +18,7 @@ inline xsimd::batch<Type> SIMDComplexMulImag (const xsimd::batch<std::complex<Ty
 
 /** SIMDComplex implementation of std::pow */
 template <typename BaseType, typename OtherType>
-inline std::enable_if_t<std::is_same_v<NumericType<OtherType>, BaseType>, xsimd::batch<std::complex<BaseType>>>
+inline std::enable_if_t<std::is_same_v<chowdsp::SampleTypeHelpers::NumericType<OtherType>, BaseType>, xsimd::batch<std::complex<BaseType>>>
     pow (const xsimd::batch<std::complex<BaseType>>& a, OtherType x)
 {
     auto absa = xsimd::abs (a);
@@ -33,7 +31,7 @@ inline std::enable_if_t<std::is_same_v<NumericType<OtherType>, BaseType>, xsimd:
 
 /** SIMDComplex implementation of std::pow */
 template <typename BaseType, typename OtherType>
-inline std::enable_if_t<std::is_same_v<NumericType<OtherType>, BaseType>, xsimd::batch<std::complex<BaseType>>>
+inline std::enable_if_t<std::is_same_v<chowdsp::SampleTypeHelpers::NumericType<OtherType>, BaseType>, xsimd::batch<std::complex<BaseType>>>
     pow (OtherType a, const xsimd::batch<std::complex<BaseType>>& z)
 {
     // same as the complex/complex xsimd implementation, except that we can skip calling arg()!

--- a/modules/dsp/chowdsp_simd/SIMD/chowdsp_SIMDComplexMathOps.h
+++ b/modules/dsp/chowdsp_simd/SIMD/chowdsp_SIMDComplexMathOps.h
@@ -18,7 +18,7 @@ inline xsimd::batch<Type> SIMDComplexMulImag (const xsimd::batch<std::complex<Ty
 
 /** SIMDComplex implementation of std::pow */
 template <typename BaseType, typename OtherType>
-inline std::enable_if_t<std::is_same_v<chowdsp::SampleTypeHelpers::NumericType<OtherType>, BaseType>, xsimd::batch<std::complex<BaseType>>>
+inline std::enable_if_t<std::is_same_v<SampleTypeHelpers::NumericType<OtherType>, BaseType>, xsimd::batch<std::complex<BaseType>>>
     pow (const xsimd::batch<std::complex<BaseType>>& a, OtherType x)
 {
     auto absa = xsimd::abs (a);
@@ -31,7 +31,7 @@ inline std::enable_if_t<std::is_same_v<chowdsp::SampleTypeHelpers::NumericType<O
 
 /** SIMDComplex implementation of std::pow */
 template <typename BaseType, typename OtherType>
-inline std::enable_if_t<std::is_same_v<chowdsp::SampleTypeHelpers::NumericType<OtherType>, BaseType>, xsimd::batch<std::complex<BaseType>>>
+inline std::enable_if_t<std::is_same_v<SampleTypeHelpers::NumericType<OtherType>, BaseType>, xsimd::batch<std::complex<BaseType>>>
     pow (OtherType a, const xsimd::batch<std::complex<BaseType>>& z)
 {
     // same as the complex/complex xsimd implementation, except that we can skip calling arg()!


### PR DESCRIPTION
I got a compiler error, which can easily be fixed by adding the namespace to NumericType.
As a by-product you can remove the using namespace SampleTypeHelpers.

```
In file included from /.../cmake-build-debug/_deps/chowdsp_utils-src/modules/dsp/chowdsp_simd/chowdsp_simd.h:70:
/.../cmake-build-debug/_deps/chowdsp_utils-src/modules/dsp/chowdsp_simd/SIMD/chowdsp_SIMDComplexMathOps.h:23:40: error: reference to 'NumericType' is ambiguous
inline std::enable_if_t<std::is_same_v<NumericType<OtherType>, BaseType>, xsimd::batch<std::complex<BaseType>>>
                                       ^
/.../cmake-build-debug/_deps/chowdsp_wdf-src/include/chowdsp_wdf/wdft/../math/sample_type.h:30:1: note: candidate found by name lookup is 'chowdsp::NumericType'
using NumericType = typename SampleTypeHelpers::ElementType<T>::Type;
^
/.../cmake-build-debug/_deps/chowdsp_utils-src/modules/dsp/chowdsp_simd/SIMD/chowdsp_SampleTypeHelpers.h:39:5: note: candidate found by name lookup is 'chowdsp::SampleTypeHelpers::NumericType'
    using NumericType = typename TypeTraits<SampleType>::ElementType;
    ^
[...]
In file included from /.../cmake-build-debug/_deps/wavedigitalfilters-src/BaxandallEQ/src/BaxandallWDF.h:3:
In file included from /.../cmake-build-debug/_deps/chowdsp_utils-src/modules/dsp/chowdsp_simd/chowdsp_simd.h:70:
/.../cmake-build-debug/_deps/chowdsp_utils-src/modules/dsp/chowdsp_simd/SIMD/chowdsp_SIMDComplexMathOps.h:36:40: error: reference to 'NumericType' is ambiguous
inline std::enable_if_t<std::is_same_v<NumericType<OtherType>, BaseType>, xsimd::batch<std::complex<BaseType>>>
                                       ^
/.../cmake-build-debug/_deps/chowdsp_wdf-src/include/chowdsp_wdf/wdft/../math/sample_type.h:30:1: note: candidate found by name lookup is 'chowdsp::NumericType'
using NumericType = typename SampleTypeHelpers::ElementType<T>::Type;
^
/.../cmake-build-debug/_deps/chowdsp_utils-src/modules/dsp/chowdsp_simd/SIMD/chowdsp_SampleTypeHelpers.h:39:5: note: candidate found by name lookup is 'chowdsp::SampleTypeHelpers::NumericType'
    using NumericType = typename TypeTraits<SampleType>::ElementType;
    ^
21 warnings and 2 errors generated.
```