### PR TITLE
Add assignment operators in parameter classes

### DIFF
--- a/modules/plugin/chowdsp_parameters/ParamUtils/chowdsp_ParameterTypes.h
+++ b/modules/plugin/chowdsp_parameters/ParamUtils/chowdsp_ParameterTypes.h
@@ -56,6 +56,12 @@ public:
 
     using Ptr = OptionalPointer<FloatParameter>;
 
+    FloatParameter& operator= (float newValue)
+    {
+        AudioParameterFloat::operator= (newValue);
+        return *this;
+    }
+
     /** Returns the default value for the parameter. */
     float getDefaultValue() const override { return unsnappedDefault; }
 
@@ -151,6 +157,12 @@ public:
     }
 
     using Ptr = OptionalPointer<BoolParameter>;
+
+    BoolParameter& operator= (bool newValue)
+    {
+        AudioParameterBool::operator= (newValue);
+        return *this;
+    }
 
 private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (BoolParameter)

--- a/modules/plugin/chowdsp_parameters/ParamUtils/chowdsp_ParameterTypes.h
+++ b/modules/plugin/chowdsp_parameters/ParamUtils/chowdsp_ParameterTypes.h
@@ -148,6 +148,13 @@ public:
         return magic_enum::enum_value<EnumType> ((size_t) getIndex());
     }
 
+    /**
+     * Sets the parameter value.
+     * This will result in a call @c setValueNotifyingHost, so make sure that's what you want.
+     * Especially if calling this from the audio thread!
+     */
+    void setParameterValue (EnumType newValue) { AudioParameterChoice::operator= (static_cast<int> (*magic_enum::enum_index (newValue))); }
+
     using Ptr = OptionalPointer<EnumChoiceParameter>;
 
 private:

--- a/modules/plugin/chowdsp_parameters/ParamUtils/chowdsp_ParameterTypes.h
+++ b/modules/plugin/chowdsp_parameters/ParamUtils/chowdsp_ParameterTypes.h
@@ -56,11 +56,12 @@ public:
 
     using Ptr = OptionalPointer<FloatParameter>;
 
-    FloatParameter& operator= (float newValue)
-    {
-        AudioParameterFloat::operator= (newValue);
-        return *this;
-    }
+    /**
+     * Sets the parameter value.
+     * This will result in a call @c setValueNotifyingHost, so make sure that's what you want.
+     * Especially if calling this from the audio thread!
+     */
+    void setParameterValue (float newValue) { AudioParameterFloat::operator= (newValue); }
 
     /** Returns the default value for the parameter. */
     float getDefaultValue() const override { return unsnappedDefault; }
@@ -158,11 +159,12 @@ public:
 
     using Ptr = OptionalPointer<BoolParameter>;
 
-    BoolParameter& operator= (bool newValue)
-    {
-        AudioParameterBool::operator= (newValue);
-        return *this;
-    }
+    /**
+     * Sets the parameter value.
+     * This will result in a call @c setValueNotifyingHost, so make sure that's what you want.
+     * Especially if calling this from the audio thread!
+     */
+    void setParameterValue (bool newValue) { AudioParameterBool::operator= (newValue); }
 
 private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (BoolParameter)

--- a/modules/plugin/chowdsp_parameters/ParamUtils/chowdsp_ParameterTypes.h
+++ b/modules/plugin/chowdsp_parameters/ParamUtils/chowdsp_ParameterTypes.h
@@ -103,6 +103,13 @@ public:
     /** Returns the default value for the parameter. */
     int getDefaultIndex() const noexcept { return defaultChoiceIndex; }
 
+    /**
+     * Sets the parameter value.
+     * This will result in a call @c setValueNotifyingHost, so make sure that's what you want.
+     * Especially if calling this from the audio thread!
+     */
+    void setParameterValue (int newValue) { AudioParameterChoice::operator= (newValue); }
+
 private:
     const int defaultChoiceIndex = 0;
 

--- a/tests/plugin_tests/chowdsp_parameters_test/ParamHelpersTest.cpp
+++ b/tests/plugin_tests/chowdsp_parameters_test/ParamHelpersTest.cpp
@@ -103,6 +103,8 @@ TEST_CASE ("Param Helpers Test", "[plugin][parameters]")
         REQUIRE_MESSAGE (modeParam.get() == Mode_1, "Default value is incorrect!");
         modeParam.setValueNotifyingHost (1.0f);
         REQUIRE_MESSAGE (modeParam.get() == Mode_3, "Set value is incorrect!");
+        modeParam.setParameterValue (Mode_2);
+        REQUIRE_MESSAGE (modeParam.get() == Mode_2, "Set value is incorrect!");
     }
 
     SECTION ("Create Semitones Param Test")


### PR DESCRIPTION
Hi!

I've found it useful to add some assignment operators in the parameter types.
As far as I know, it's the only way to avoid having to manually normalise the new value.

With the current setup I need to do this
```cpp
auto tempo = processor.getState().params.tempo;
tempo->setValueNotifyingHost (tempo->convertTo0to1 (newBpmValue));
```
which could just be
```cpp
processor.getState().params.tempo = newBpmValue;
```

It seemed straightforward to do for the bool and float params, so I've just started with those.
Is this something you'd consider adding?
Or maybe I've overlooked some simpler solution..