### PR TITLE
Stop HighResolutionTimer on ~LinearPhase3WayCrossover()

### DIFF
--- a/modules/dsp/chowdsp_dsp_utils/Processors/chowdsp_LinearPhase3WayCrossover.h
+++ b/modules/dsp/chowdsp_dsp_utils/Processors/chowdsp_LinearPhase3WayCrossover.h
@@ -11,6 +11,11 @@ public:
 
     LinearPhase3WayCrossover() = default;
 
+    ~LinearPhase3WayCrossover() override
+    {
+        stopTimer();
+    }
+
     /** Prepares the crossover filter with an IR length and initial crossover frequencies */
     void prepare (const juce::dsp::ProcessSpec& spec, int irLength, float lowBandCrossoverHz, float highBandCrossoverHz)
     {


### PR DESCRIPTION
Leaving the timer runnning can cause crashes when plugins are destroyed (AU format seems particularly prone) 