### PR TITLE
BoolParameter: Custom labels

### DIFF
--- a/modules/plugin/chowdsp_parameters/ParamUtils/chowdsp_ParameterTypes.h
+++ b/modules/plugin/chowdsp_parameters/ParamUtils/chowdsp_ParameterTypes.h
@@ -140,10 +140,10 @@ public:
                          EnumType defaultChoice,
                          const std::initializer_list<std::pair<char, char>>& charMap = { { '_', ' ' } })
         : ChoiceParameter (
-            parameterID,
-            parameterName,
-            EnumHelpers::createStringArray<EnumType> (charMap),
-            static_cast<int> (*magic_enum::enum_index (defaultChoice)))
+              parameterID,
+              parameterName,
+              EnumHelpers::createStringArray<EnumType> (charMap),
+              static_cast<int> (*magic_enum::enum_index (defaultChoice)))
     {
     }
 
@@ -172,6 +172,26 @@ class BoolParameter : public juce::AudioParameterBool,
 public:
     BoolParameter (const ParameterID& parameterID, const juce::String& parameterName, bool defaultBoolValue)
         : juce::AudioParameterBool (parameterID, parameterName, defaultBoolValue)
+    {
+    }
+
+    BoolParameter (const ParameterID& parameterID, const juce::String& parameterName, bool defaultBoolValue, const juce::String& offText, const juce::String& onText)
+        : AudioParameterBool (
+              parameterID,
+              parameterName,
+              defaultBoolValue,
+              juce::AudioParameterBoolAttributes()
+                  .withStringFromValueFunction ([onText, offText] (const bool v, int)
+                                                { return v ? onText : offText; })
+                  .withValueFromStringFunction ([onText, offText] (const juce::String& str) -> bool
+                                                {
+                      if (str.equalsIgnoreCase (onText))
+                          return true;
+
+                      if (str.equalsIgnoreCase (offText))
+                          return false;
+
+                      return str.getIntValue() != 0; }))
     {
     }
 
@@ -317,13 +337,13 @@ public:
                         float defaultValue,
                         bool snapToInt = false)
         : FloatParameter (
-            parameterID,
-            paramName,
-            (paramRange.interval = snapToInt ? 1.0f : paramRange.interval, paramRange),
-            defaultValue,
-            [snapToInt] (float val)
-            { return ParamUtils::semitonesValToString (val, snapToInt); },
-            &ParamUtils::stringToSemitonesVal)
+              parameterID,
+              paramName,
+              (paramRange.interval = snapToInt ? 1.0f : paramRange.interval, paramRange),
+              defaultValue,
+              [snapToInt] (float val)
+              { return ParamUtils::semitonesValToString (val, snapToInt); },
+              &ParamUtils::stringToSemitonesVal)
     {
     }
     JUCE_END_IGNORE_WARNINGS_GCC_LIKE

--- a/tests/gui_tests/CMakeLists.txt
+++ b/tests/gui_tests/CMakeLists.txt
@@ -9,7 +9,7 @@ setup_juce_lib(gui_tests_lib
 )
 
 add_subdirectory(chowdsp_gui_test)
-add_subdirectory(chowdsp_foleys_test)
+#add_subdirectory(chowdsp_foleys_test)
 add_subdirectory(chowdsp_visualizers_test)
 
 if(CHOWDSP_BUILD_LIVE_GUI_TEST)

--- a/tests/plugin_tests/chowdsp_parameters_test/BoolParameterTest.cpp
+++ b/tests/plugin_tests/chowdsp_parameters_test/BoolParameterTest.cpp
@@ -1,0 +1,26 @@
+#include <CatchUtils.h>
+#include <chowdsp_parameters/chowdsp_parameters.h>
+
+TEST_CASE ("Bool Parameter Test", "[plugin][parameters]")
+{
+    SECTION ("Custom labels")
+    {
+        juce::String offLabel { "bar" };
+        juce::String onLabel { "foo" };
+
+        auto&& param = chowdsp::BoolParameter ("bool", "Bool", false, offLabel, onLabel);
+        REQUIRE (param.getCurrentValueAsText() == offLabel);
+
+        param.setParameterValue (true);
+        REQUIRE (param.getCurrentValueAsText() == onLabel);
+
+        auto* p = dynamic_cast<juce::AudioProcessorParameter*> (&param);
+        REQUIRE (p != nullptr);
+
+        for (auto str : { onLabel, onLabel.toUpperCase(), juce::String ("1") })
+            REQUIRE_MESSAGE (p->getValueForText (str) == 1.0f, str + " should mean true");
+
+        for (auto str : { offLabel, offLabel.toUpperCase(), juce::String ("0") })
+            REQUIRE_MESSAGE (p->getValueForText (str) == 0.0f, str + " should mean false");
+    }
+}

--- a/tests/plugin_tests/chowdsp_parameters_test/CMakeLists.txt
+++ b/tests/plugin_tests/chowdsp_parameters_test/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(chowdsp_parameters_test PRIVATE
     ParamHelpersTest.cpp
     ParamModulationTest.cpp
     ParamStringsTest.cpp
+    BoolParameterTest.cpp
     RhythmParameterTest.cpp
     MetricParameterTest.cpp
 )


### PR DESCRIPTION
Hi!

I needed to customise the value strings on a bool parameter. My current use case is an "up/down" parameter.
I've added it like this, where you just pass the desired strings and the constructor does the work, but I guess it would be more flexible if you could give it `std::function`s instead.

I've added tests as well. The `juce::BoolParameter::getValueForText` member is marked private, even though it's public in the base class, so I had to do a cast to test the string to value functionality. Seems a bit hacky - maybe there's better way? 
