### PR TITLE
PresetSaverLoader: don't dirty-check against an invalid current preset

### DIFF
--- a/modules/plugin/chowdsp_presets_v2/Backend/chowdsp_PresetSaverLoader.cpp
+++ b/modules/plugin/chowdsp_presets_v2/Backend/chowdsp_PresetSaverLoader.cpp
@@ -28,7 +28,7 @@ void PresetSaverLoader::initializeListeners (ParamHolder& params, ParameterListe
                     [this, &param]
                     {
                         juce::ignoreUnused (param);
-                        if (areWeInTheMidstOfAPresetChange || currentPreset == nullptr)
+                        if (areWeInTheMidstOfAPresetChange || currentPreset == nullptr || ! currentPreset->isValid())
                             return;
 
                         using ParamElementType = ParameterTypeHelpers::ParameterElementType<std::remove_reference_t<decltype (param)>>;


### PR DESCRIPTION
### The problem

`PresetSaverLoader::initializeListeners` guards the per-parameter listener on `currentPreset == nullptr`, but not on the preset actually being valid:

```cpp
if (areWeInTheMidstOfAPresetChange || currentPreset == nullptr)
    return;
...
const auto presetParamValue01 = param.convertTo0to1 (
    currentPreset->getState().value (param.paramID, param.getDefault()));
```

`Preset::isValid()` is `! state.is_null()`, and `nlohmann::json::value()` throws `type_error.306` — *"cannot use value() with null"* — for a null json. So if the current preset is non-null but invalid, changing **any** non-preset-agnostic parameter throws out of a message-thread listener.

### Why a non-null invalid preset is reachable

`Preset::initialiseSafe` deliberately swallows a failure from `initialise` and leaves the object in place with a cleared state:

```cpp
catch (const std::exception& exception)
{
    juce::Logger::writeToLog ("Error loading preset from " + source + ": " + ...);
    jassertfalse;
    state = {};       // <-- now invalid, but the Preset object survives
    file = juce::File {};
}
```

and `PresetState::deserialize_json` stores whatever it constructs for any non-null input:

```cpp
if (deserial.is_null()) { reset(); return; }
set (PresetPtr { deserial });
```

`initialise` throws when the preset was saved by a different plugin (`presetJson.at (pluginTag) != JucePlugin_Name`), when `name`/`vendor` are empty, when `version` is empty, and via `at()` for any missing key. So restoring a session — or loading a preset file — that is foreign, truncated or hand-edited lands in exactly this state.

The unpleasant part is the delay: nothing goes wrong at load time (the `jassertfalse` is a no-op in release), and the throw happens later on the user's next parameter change, which makes it look unrelated to preset loading.

### The fix

Also check validity in the guard. One line.

### Note

`loadPresetParameters` is **not** affected by the same case — it uses `state.contains (...)`, which is null-safe, so a null state there merely resets parameters to their defaults. That asymmetry is why the guard belongs in the listener rather than around `getState()`.

I've been running this patch locally against `chowdsp_presets_v2` in a shipping plugin.